### PR TITLE
Fix karma with PhantomJS on travis

### DIFF
--- a/app/components/view/view.page.js
+++ b/app/components/view/view.page.js
@@ -8,7 +8,7 @@ var get = function (chapter) {
 };
 
 var getSelectedChapterTitle = function () {
-  return $('.chapter-heading > h2').getText();
+  return $('.chapter-heading > h2').getText().then(function (title) { return title.toUpperCase() });
 };
 
 var getMenuIcon = function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ gulp.task('_start-server', function () {
   server.run(['test/server.js']);
 });
 
-gulp.task('_test-functional', ['_start-server'], function () {
+gulp.task('_test-functional', ['_start-server', 'build-css'], function () {
   return gulp.src(['./app/components/**/*.fn.spec.js'])
       .pipe(protractor({
         configFile: 'protractor.conf.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,7 @@ module.exports = function(config) {
       'node_modules/angular/angular.js',
       'node_modules/angular-ui-router/release/angular-ui-router.js',
       'node_modules/angular-mocks/angular-mocks.js',
+      'node_modules/phantomjs-function-bind-polyfill/index.js',
       'app/components/**/*.html',
       'app/components/**/*.js' ],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "karma-ng-html2js-preprocessor": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.3",
     "phantomjs": "^1.9.19",
-    "protractor": "^1.8.0"
+    "protractor": "^1.8.0",
+    "phantomjs-function-bind-polyfill": "1.0.0"
   },
   "dependencies": {
     "angular": "^1.4.8",


### PR DESCRIPTION
I had the same problem pop up today. Looks like something in update angular is using Function.prototype.bind and PhantomJS 1.9.x doesn't support it. PhantomJS 2.x supports it, but Travis doesn't yet.

Using polyfill for `Function.prototype.bind`. Karma tests now pass, still protractor tests failing but pretty sure that's unrelated.
